### PR TITLE
analyzeall: Don't write masks back into specs

### DIFF
--- a/analyzeall.lua
+++ b/analyzeall.lua
@@ -20,11 +20,12 @@ local function analyzeProject(self)
   local projectPath = ide:GetProject()
   if projectPath then
     local specs = self:GetConfig().ignore or {}
-    for i in ipairs(specs) do specs[i] = "^"..path2mask(specs[i]).."$" end
+    local masks = {}
+    for i in ipairs(specs) do masks[i] = "^"..path2mask(specs[i]).."$" end
     for _, filePath in ipairs(FileSysGetRecursive(projectPath, true, "*.lua")) do
       local checkPath = filePath:gsub(projectPath, "")
       local ignore = false
-      for _, spec in ipairs(specs) do
+      for _, spec in ipairs(masks) do
         ignore = ignore or checkPath:find(spec)
       end
       if not ignore then


### PR DESCRIPTION
Doing so renders the original specs invalid, resulting in subsequent
calls of analyzeProject() not ignore the original specs.
This also makes masking the specs an increasingly complex operation
as `specs` grows, rendering subsequent uses of analyzeProject()
take exponentially more time up to the point of unusability.

This commit solves this problem by creating a local `masks` table,
 which the masks are written to and read from.
