### PR TITLE
Renamed the MCServer API file.

### DIFF
--- a/mcserver.lua
+++ b/mcserver.lua
@@ -9,7 +9,7 @@ local function MakeMCServerInterpreter(a_InterpreterPostfix, a_ExePostfix)
 	{
 		name = "MCServer" .. a_InterpreterPostfix,
 		description = "MCServer - the custom C++ minecraft server",
-		api = {"baselib", "mcserver"},
+		api = {"baselib", "mcserver_api"},
 
 		frun = function(self, wfilename, withdebug)
 			-- MCServer plugins are always in a "Plugins/<PluginName>" subfolder located at the executable level


### PR DESCRIPTION
The file has been renamed to avoid confusion during manual setup (there were two "mcserver.lua" files involved, one for the interpreter and one for the API).

This corresponds to commit mc-server/MCServer@f38a009b3cc5caf25d11496fda5caf75531127d0.
