### PR TITLE
MCServer: Updated cmdline for newer versions of the interpreter

### DIFF
--- a/mcserver.lua
+++ b/mcserver.lua
@@ -39,7 +39,7 @@ local function MakeMCServerInterpreter(a_Self, a_InterpreterPostfix, a_ExePostfi
 			end
 
 			-- Add a "nooutbuf" cmdline param to the server, causing it to call setvbuf to disable output buffering:
-			local Cmd = ExeName:GetFullPath() .. " nooutbuf"
+			local Cmd = ExeName:GetFullPath() .. " --no-output-buffering"
 
 			-- Force ZBS not to hide MCS window, save and restore previous state:
 			local SavedUnhideConsoleWindow = ide.config.unhidewindow.ConsoleWindowClass


### PR DESCRIPTION
The server has had an update that forced all cmdline params to be prefixed with a double-dash, as well as expanded to full wording.
Ref.: mc-server/MCServer#2065