### PR TITLE
Fix bug with todo.lua when two or more tasks have the same text

### DIFF
--- a/todo.lua
+++ b/todo.lua
@@ -6,12 +6,23 @@ local refeditor
 local spec = {iscomment = {}}
 local TODOTable = {}
 --TODO: hello ()
+
 local function mapTODOS(self,editor,event)
+
+	local tasksListStr = "Tasks List: \n\n"
+	local lineCounter = 2
+	local positions = {}
+
+	local function insertLine(line, pos)
+		tasksListStr = tasksListStr .. line
+		lineCounter = lineCounter + 1
+		positions[lineCounter] = pos
+	end
+
     local text = editor:GetText()
     local i = 0
     local counter = 1
-    local tasksListStr = "Tasks List: \n"
-    tasksListStr = tasksListStr.."\n"
+
     while true do
 
         --find next todo index
@@ -24,24 +35,18 @@ local function mapTODOS(self,editor,event)
         end
         j = string.find(text, "\n",i+1)
         local taskStr = string.sub(text, i+5,j)
-        tasksListStr = tasksListStr..tostring(counter).."."..taskStr
-
-        refeditor:SetReadOnly(false)
-        refeditor:SetText(tasksListStr)
-        refeditor:SetReadOnly(true)
+        insertLine(tostring(counter).."."..taskStr, i)
         counter = counter+1
     end
 
     --On click of a task, go to relevant position in the text
     refeditor:Connect(wxstc.wxEVT_STC_DOUBLECLICK,
     function(event)
-        local line = refeditor:GetCurrentLine()
-        local linetx = string.sub(refeditor:GetLine(line), 4)
-        i = string.find(editor:GetText(), linetx, 1, true)
-        if i then
-        editor:GotoPosEnforcePolicy(i-1)
-        if not ide:GetEditorWithFocus(editor) then ide:GetDocument(editor):SetActive() end
-        end
+        local line = refeditor:GetCurrentLine() +1
+		local position = positions[line]
+		if not position then return end
+		editor:GotoPosEnforcePolicy(position - 1)
+		if not ide:GetEditorWithFocus(editor) then ide:GetDocument(editor):SetActive() end
     end)
 
 end


### PR DESCRIPTION
With current version, if two or more tasks have the same text, clicking on them always point the editor to the first occurence.