### PR TITLE
Todoall: Fixed and revised from #57

### DIFF
--- a/todoall.lua
+++ b/todoall.lua
@@ -1,5 +1,7 @@
 -- Copyright 2017 Paul Kulchenko, ZeroBrane LLC; All rights reserved
 -- Contributed by Chronos Phaenon Eosphoros (@cpeosphoros)
+-- Minor changes by Paul Reilly, inc borrowing Mark Fainstein's new  
+-- pattern matching from todo.lua
 --
 -- Some code taken from those plugins:
 -- todo.lua:
@@ -15,9 +17,9 @@
 -- Example: 
 --
 -- todoall = { 
---   patterns = { { name = "TODO",  pattern = "%-%-TODO[%s:;>]"  },
---                { name = "FIXME", pattern = "%-%-FIXME[%s:;>]" },
---                { name = "WTF",   pattern = "%-%-WTF[%s:;>]"   }
+--   patterns = { { name = "TODO",  pattern = "TODO[%s:;>]"  },
+--                { name = "FIXME", pattern = "FIXME[%s:;>]" },
+--                { name = "WTF",   pattern = "WTF[%s:;>]"   }
 --              }
 -- } 
 --
@@ -50,7 +52,8 @@ local function mapTODOS(fileName, text)
       end
       local j = string.find(text, "\n",i+1)
       local taskStr
-      taskStr = string.sub(text, i+3+#pattern.name, j)
+      -- 1 is for the extra char after the task name
+      taskStr = string.sub(text, i+1+#pattern.name, j)
       if first == false then
         first = true
         tasks[#tasks+1] = {pos = -1, str = pattern.name .. "s\n"}
@@ -182,8 +185,8 @@ return {
   onRegister = function(self)
     patterns = self:GetConfig().patterns 
     if not patterns or not next(patterns) then
-       patterns = { { name = "TODO",  pattern = "%-%-TODO[%s:;>]" },
-                    { name = "FIXME", pattern = "%-%-FIXME[%s:;>]" }
+       patterns = { { name = "TODO",  pattern = "TODO[%s:;>]"  },
+                    { name = "FIXME", pattern = "FIXME[%s:;>]" }
                   }
     end
 
@@ -254,3 +257,4 @@ return {
     mapProject(self, editor)
   end
 }
+

--- a/todoall.lua
+++ b/todoall.lua
@@ -86,7 +86,7 @@ local function mapTODOS(fileName, text, isTextRawFile)
       local taskStr
       -- 1 is for the extra char after the task name
       taskStr = string.sub(text, i+1+#pattern.name, j)
-      if j == #text then taskStr = taskStr .. "\n" end -- add newline if EOF
+      if j == #text and isTextRawFile then taskStr = taskStr .. "\n" end -- add newline if EOF
       if first == false then
         first = true
         tasks[#tasks+1] = {pos = -1, str = pattern.name .. "s\n"}
@@ -209,6 +209,7 @@ local function mapProject(self, editor)
     
       editor:GotoPosEnforcePolicy(position.pos - 1)
       if not ide:GetEditorWithFocus(editor) then ide:GetDocument(editor):SetActive() end
+      refeditor:SetEmptySelection(0)
     end)
 end
 
@@ -264,7 +265,7 @@ return {
     e:Connect(wxstc.wxEVT_STC_DO_DROP, function(event) event:SetDragResult(wx.wxDragNone) end)
 
     local menu = ide:GetMenuBar():GetMenu(ide:GetMenuBar():FindMenu(TR("&Project")))
-
+    
     menu:InsertCheckItem(4, id, TR("Tasks List")..KSC(id))
 
     menu:Connect(id, wx.wxEVT_COMMAND_MENU_SELECTED, function ()
@@ -327,15 +328,6 @@ return {
   onEditorSave = function(self, editor)
     if not fileTasks[fileNameFromPath(ide:GetDocument(editor):GetFilePath())] then
       mapProject(self, editor)
-    end
-  end,
-  
-  onEditorFocusSet = function(self, editor)
-    if projectLoaded then
-      -- this is nil when loading a file
-      if ide:GetDocument(editor):GetFilePath() then
-        mapProject(self, editor)
-      end
     end
   end,
 

--- a/todoall.lua
+++ b/todoall.lua
@@ -70,18 +70,23 @@ local function mapTODOS(fileName, text, isTextRawFile)
       -- wx editor length, so if it's a file read adjust for line endings
       local adj = 0
       local nl = string.find(text, "\n", pos + 1)
+      -- handle end of file when no more newlines
+      if nl == nil then nl = #text end
       if isTextRawFile then
         while nl < i do
           numLines = numLines + 1
           nl = string.find(text, "\n", nl+1)
+          if nl == nil then nl = #text end
         end
         adj = numLines
       end
       
       local j = string.find(text, "\n",i+1)
+      if j == nil then j = #text end --  handle EOF
       local taskStr
       -- 1 is for the extra char after the task name
       taskStr = string.sub(text, i+1+#pattern.name, j)
+      if j == #text then taskStr = taskStr .. "\n" end -- add newline if EOF
       if first == false then
         first = true
         tasks[#tasks+1] = {pos = -1, str = pattern.name .. "s\n"}

--- a/todoall.lua
+++ b/todoall.lua
@@ -1,11 +1,26 @@
 -- Copyright 2017 Paul Kulchenko, ZeroBrane LLC; All rights reserved
 -- Contributed by Chronos Phaenon Eosphoros (@cpeosphoros)
+--
 -- Some code taken from those plugins:
 -- todo.lua:
 -- 	Copyright 2014 Paul Kulchenko, ZeroBrane LLC; All rights reserved
 -- 	Contributed by Mark Fainstein
 -- analyzeall.lua:
 -- 	Copyright 2014 Paul Kulchenko, ZeroBrane LLC; All rights reserved
+--
+--
+-- In your system or user config/preferences file, you can set the tokens
+-- used by this package...
+--
+-- Example: 
+--
+-- todoall = { 
+--   patterns = { { name = "TODO",  pattern = "%-%-TODO[%s:;>]"  },
+--                { name = "FIXME", pattern = "%-%-FIXME[%s:;>]" },
+--                { name = "WTF",   pattern = "%-%-WTF[%s:;>]"   }
+--              }
+-- } 
+--
 
 local id = ID("TODOAllpanel.referenceview")
 local TODOpanel = "TODOAllpanel"
@@ -20,21 +35,32 @@ local function path2mask(s)
 end
 
 local fileTasks
+local patterns = {}
 
 local function mapTODOS(fileName, text)
-  local i = 0
   local tasks = {}
-  while true do
-    --find next todo index
-    i = string.find(text, "TODO:", i+1)
-    if i == nil then
-      fileTasks[fileName] = tasks
-      break
+  for _, pattern in ipairs(patterns) do
+    local first = false
+    local i = 0
+    while true do
+      --find next todo index
+      i = string.find(text, pattern.pattern, i+1)
+      if i == nil then
+        break
+      end
+      local j = string.find(text, "\n",i+1)
+      local taskStr
+      taskStr = string.sub(text, i+3+#pattern.name, j)
+      if first == false then
+        first = true
+        tasks[#tasks+1] = {pos = -1, str = pattern.name .. "s\n"}
+        tasks[#tasks+1] = {pos = i,  str = taskStr}
+      else
+        tasks[#tasks+1] = {pos = i,  str = taskStr}
+      end
     end
-    local j = string.find(text, "\n",i+1)
-    local taskStr = string.sub(text, i+5, j)
-    table.insert(tasks, {pos = i, str = taskStr})
   end
+  fileTasks[fileName] = tasks
 end
 
 local function readfile(filePath)
@@ -44,7 +70,7 @@ local function readfile(filePath)
   return data
 end
 
-function sortedKeys(tbl)
+local function sortedKeys(tbl)
   local sorted = {}
   for k, _ in pairs (tbl) do
     table.insert(sorted, k)
@@ -59,8 +85,8 @@ local function fileNameFromPath(filePath)
   return filePath:gsub(projectPath, "")
 end
 
+-- main function, called on project load and on new char in editor
 local function mapProject(self, editor)
-
   local specs = self:GetConfig().ignore or {}
   if editor then
     mapTODOS(fileNameFromPath(ide:GetDocument(editor):GetFilePath()), editor:GetText())
@@ -79,12 +105,12 @@ local function mapProject(self, editor)
       end
     end
   end
-
+  
   local files = sortedKeys(fileTasks)
-  local tasksListStr = "Tasks List: \n\n"
+  local tasksListStr = "Project Tasks: \n\n"
   local lineCounter = 2
   local positions = {}
-
+  
   local function insertLine(line, pos, file)
     tasksListStr = tasksListStr .. line
     lineCounter = lineCounter + 1
@@ -92,18 +118,32 @@ local function mapProject(self, editor)
       positions[lineCounter] = {pos = pos, file = file}
     end
   end
-
+  
+  local fileDispText = ""
+  local displayLengthLimit = 30 -- truncate file name to this length
   for _, file in ipairs(files) do
     local tasks = fileTasks[file]
     if tasks and #tasks ~= 0 then
-      insertLine(file .. ":\n", 1, file)
-      for counter, taskStr in ipairs(tasks) do
-        insertLine(counter.."."..taskStr.str, taskStr.pos, file)
+      if #file >= displayLengthLimit then
+        fileDispText = "~" .. file:sub(-displayLengthLimit)
+      else
+        fileDispText = file
+      end
+      insertLine(fileDispText .. ":\n", 1, file)
+      local counter = 1
+      for _, taskStr in ipairs(tasks) do
+        if taskStr.pos ~= -1 then
+          insertLine(counter.."." ..taskStr.str, taskStr.pos, file)
+          counter = counter + 1
+        else
+          insertLine(taskStr.str)
+          counter = 1
+        end
       end
       insertLine("\n")
     end
   end
-
+  
   refeditor:SetReadOnly(false)
   refeditor:SetText(tasksListStr)
   refeditor:SetReadOnly(true)
@@ -127,7 +167,6 @@ local function mapProject(self, editor)
         editor = ide:LoadFile(filePath)
         if not editor then error("Couldn't load " .. filePath) end
       end
-
       editor:GotoPosEnforcePolicy(position.pos - 1)
       if not ide:GetEditorWithFocus(editor) then ide:GetDocument(editor):SetActive() end
     end)
@@ -137,10 +176,17 @@ return {
   name = "Show project-wise TODO panel",
   description = "Adds a project-wise panel for showing a tasks list.",
   author = "Chronos Phaenon Eosphoros",
-  version = 0.1,
+  version = 0.2,
   dependencies = 1.60,
 
   onRegister = function(self)
+    patterns = self:GetConfig().patterns 
+    if not patterns or not next(patterns) then
+       patterns = { { name = "TODO",  pattern = "%-%-TODO[%s:;>]" },
+                    { name = "FIXME", pattern = "%-%-FIXME[%s:;>]" }
+                  }
+    end
+
     local e = ide:CreateBareEditor()
     refeditor = e
 
@@ -168,7 +214,7 @@ return {
     end
 
     e:SetReadOnly(true)
-    e:SetWrapMode(wxstc.wxSTC_WRAP_NONE)
+    e:SetWrapMode(wxstc.wxSTC_WRAP_WORD)
     e:SetupKeywords("lua",spec,ide:GetConfig().styles,ide:GetOutput():GetFont())
 
     -- remove all margins
@@ -178,12 +224,15 @@ return {
     e:Connect(wxstc.wxEVT_STC_DO_DROP, function(event) event:SetDragResult(wx.wxDragNone) end)
 
     local menu = ide:GetMenuBar():GetMenu(ide:GetMenuBar():FindMenu(TR("&Project")))
+
     menu:InsertCheckItem(4, id, TR("Tasks List")..KSC(id))
+
     menu:Connect(id, wx.wxEVT_COMMAND_MENU_SELECTED, function ()
         local uimgr = ide:GetUIManager()
         uimgr:GetPane(TODOpanel):Show(not uimgr:GetPane(TODOpanel):IsShown())
         uimgr:Update()
       end)
+
     ide:GetMainFrame():Connect(id, wx.wxEVT_UPDATE_UI, function (event)
         local pane = ide:GetUIManager():GetPane(TODOpanel)
         menu:Enable(event:GetId(), pane:IsOk()) -- disable if doesn't exist
@@ -203,5 +252,5 @@ return {
 
   onEditorCharAdded = function(self, editor) --, event)
     mapProject(self, editor)
-  end,
+  end
 }

--- a/todoall.lua
+++ b/todoall.lua
@@ -318,6 +318,13 @@ return {
     end
   end,
   
+  -- implemented for saving new file, so list updates on save
+  onEditorSave = function(self, editor)
+    if not fileTasks[fileNameFromPath(ide:GetDocument(editor):GetFilePath())] then
+      mapProject(self, editor)
+    end
+  end,
+  
   onEditorFocusSet = function(self, editor)
     if projectLoaded then
       -- this is nil when loading a file
@@ -328,7 +335,10 @@ return {
   end,
 
   onEditorCharAdded = function(self, editor) --, event)
-    mapProject(self, editor)
+    -- might be in new, unsaved file
+    if ide:GetDocument(editor):GetFilePath() then
+      mapProject(self, editor)
+    end
   end
 }
 


### PR DESCRIPTION
That's those issues fixed from #57 . Well, the whitespace one is fixed by avoiding whitespace in the patterns. It was indeed a difference in file length between the raw lua file read and the wx editor file length that was causing the bad positioning on first load.

I've changed the ignore logic so that the beginning of a path relative to the project can be used to ignore everything in it. Scanning non-project files that are open on load or closed is better now too, only project files remain opened on close now.