### PR TITLE
Support for @file:my.file in Command Line Parameters

### DIFF
--- a/redis.lua
+++ b/redis.lua
@@ -1805,6 +1805,16 @@ for n, v in ipairs(params) do
     break
   end
 end
+
+-- if @file is requested, insert file contents
+for n, v in ipairs(params) do
+  if string.sub(v,1,6) == "@file:" then
+    local f = assert(io.open(string.sub(v,7), "rb"))
+    params[n] = f:read("*all")
+    f:close()
+  end
+end
+
 -- load the script to debug; check for any reported errors
 msg, err = check(client:eval(code, keys, unpack(params)))
 


### PR DESCRIPTION
This patch adds support for @file:my.file in Command Line Parameters. The parameter is replaced by the file contents of the requested file.
By design: only supported in ARGV, not in KEYS. Can be repeated for multiple files, and combined with normal parameters.
Needed when passing binary data (like MSGPACK), or formatted human-readable JSON, to the Redis Lua debug session.