### PR TITLE
colourpicker: normalized float format added

### DIFF
--- a/colourpicker.lua
+++ b/colourpicker.lua
@@ -6,12 +6,22 @@ local function insertcolour(event)
   local colour = wx.wxColour(rgb and "rgb("..rgb..")" or wx.wxBLACK)
   local newcolour = wx.wxGetColourFromUser(ide:GetMainFrame(), colour)
   if newcolour:Ok() then -- user selected some colour
+    local newtext
     if editor:GetCharAt(editor:GetCurrentPos()-1) == string.byte('x') then
       editor:DeleteRange(editor:GetCurrentPos()-1, 1)
-      local newtext2 = newcolour:GetAsString(wx.wxC2S_HTML_SYNTAX):match("%x+%x+%x+") or ""
-      ide:GetEditor():AddText(newtext2)
+      newtext = newcolour:GetAsString(wx.wxC2S_HTML_SYNTAX):match("%x+%x+%x+") or ""
+      ide:GetEditor():AddText(newtext)
+    elseif editor:GetCharAt(editor:GetCurrentPos()-1) == string.byte('f')
+        then  -- normalized float format, used by love.graphics from version 11
+      editor:DeleteRange(editor:GetCurrentPos()-1, 1)
+      local rgb = newcolour:GetRGB()
+      local blue = math.floor(rgb / 16^4)
+      local green = math.floor(rgb/16^2 - blue*16^2)
+      local red = math.floor(rgb - green*16^2 - blue*16^4)
+      newtext = string.format("%f, %f, %f", red/255, green/255, blue/255)
+      ide:GetEditor():AddText(newtext)
     else
-      local newtext = newcolour:GetAsString(wx.wxC2S_CSS_SYNTAX):match("%d+,%s*%d+,%s*%d+") or ""
+      newtext = newcolour:GetAsString(wx.wxC2S_CSS_SYNTAX):match("%d+,%s*%d+,%s*%d+") or ""
       ide:GetEditor():ReplaceSelection(newtext)
     end
   end


### PR DESCRIPTION
According to the Löve2D wiki, this format is used from version 11.0
https://love2d.org/wiki/love.graphics
so I decided to add it to the colourpicker plugin.

Usage:
Write `f` in the editor, then
` View > Color Picker Window`
or
` Right Click > Insert Colour`
pick your color, press Select, and the color components will be added
with values whitin the range 0 to 1, comma-separated, as required by the
love.graphics module.