### PR TITLE
Handle windows paths in analyzeall.lua

### DIFF
--- a/analyzeall.lua
+++ b/analyzeall.lua
@@ -18,11 +18,12 @@ local function analyzeProject(self)
   local errors, warnings = 0, 0
   local projectPath = ide:GetProject()
   if projectPath then
+    local projectMask = path2mask(projectPath)
     local specs = self:GetConfig().ignore or {}
     local masks = {}
     for i in ipairs(specs) do masks[i] = "^"..path2mask(specs[i]).."$" end
     for _, filePath in ipairs(ide:GetFileList(projectPath, true, "*.lua")) do
-      local checkPath = filePath:gsub(projectPath, "")
+      local checkPath = filePath:gsub(projectMask, "")
       local ignore = false
       for _, spec in ipairs(masks) do
         ignore = ignore or checkPath:find(spec)


### PR DESCRIPTION
I was having issues getting the ignore list working on Windows. 
Figured out it had to do with gsub expecting a pattern instead of a literal string and the `\\` characters in windows paths probably tripping it up.

`filePath:gsub(projectPath, "")` would not find any matches and `checkPath` would contain the full path to the file instead of a path rooted at the projectPath. Using a pattern similar to the masks gets the gsub working.