### PR TITLE
[WIP] Add. Code snippet plugin

### DIFF
--- a/snippets.lua
+++ b/snippets.lua
@@ -1,0 +1,133 @@
+if not package_require then
+  local package_path = {
+    '.',
+    'packages/',
+    '../packages/',
+    MergeFullPath(ide.oshome, '.' .. ide.appname .. '/packages')
+  }
+
+  local package_loaded = {}
+
+  function package_require(m)
+    local module = package_loaded[m]
+    if module ~= nil then
+      assert(module, 'cycle for module:' .. m)
+      return module
+    end
+
+    package_loaded[m] = false
+
+    local rpath = string.gsub(m, '%.', '/') .. '.lua'
+    for _, ppath in ipairs(package_path) do
+      local full_path = MergeFullPath(ppath, rpath)
+      if wx.wxFileExists(full_path) then
+        local loader = assert(loadfile(full_path))
+        package_loaded[m] = assert(loader(m))
+        return package_loaded[m]
+      end
+    end
+
+    error('can not load ' .. m)
+  end
+end
+
+local HotKeyToggle   = package_require 'snippets.hot_key_toggle'
+local SnippetManager = package_require 'snippets.manager'
+
+local manager = SnippetManager:new()
+
+local Package = {
+  name = "Code snippets",
+  description = [[
+  Code based on Mitchell Foral' scite-tools pacakage.
+]],
+  author = "Alexey Melnichuk",
+  version = "0.0.1",
+  dependencies = "1.80",
+}
+
+local actions = {
+    insert     = function (editor) manager:insert(editor)          end,
+    prev       = function (editor) manager:prev(editor)            end,
+    cancel     = function (editor) manager:cancel_current(editor)  end,
+    cancel_all = function (editor) manager:cancel(editor)          end,
+    list       = function (editor) manager:snippet_list(editor)    end,
+    show_scope = function (editor) manager:show_scope(editor)      end,
+}
+
+local hot_keys = {}
+
+local function OnTabActivation(self, editor, event)
+  local mod = event:GetModifiers()
+  if (mod ~= 0) and (mod ~= wx.wxMOD_SHIFT) then
+    return true
+  end
+
+  local key = event:GetKeyCode()
+  if key ~= wx.WXK_TAB then
+    return true
+  end
+
+  -- tab activation does not work when selected text
+  local selections = editor:GetSelections()
+  if selections > 1 then
+    return true
+  end
+
+  if not manager:has_active_snippet(editor) then
+    local selection_pos_start, selection_pos_end = editor:GetSelection()
+    if selection_pos_start ~= selection_pos_end then
+      return true
+    end
+  end
+
+  if mod == wx.wxMOD_SHIFT then
+    if not manager:has_active_snippet(editor) then
+      return true
+    end
+    manager:prev(editor)
+    return false
+  end
+
+  if manager:insert(editor) then
+    return false
+  end
+
+  return true
+end
+
+Package.onRegister = function(package)
+  local config = manager:load_config(package:GetConfig())
+
+  for key, handler in pairs(config.settings.keys) do
+    handler = assert(actions[handler], 'Unsupported action: ' .. tostring(handler))
+    local hot_key = HotKeyToggle:new(key):set(function() handler(ide:GetEditor()) end)
+    table.insert(hot_keys, hot_key)
+  end
+
+  for _, key in ipairs(config:get_key_activators()) do
+    local hot_key = HotKeyToggle:new(key):set(function() manager:insert(ide:GetEditor(), key) end)
+    table.insert(hot_keys, hot_key)
+  end
+
+  if config.settings.tab_activation then
+    Package.onEditorKeyDown = OnTabActivation
+  end
+end
+
+Package.onUnRegister = function()
+  for _, hot_key in ipairs(hot_keys) do
+    hot_key:unset()
+  end
+  hot_keys = {}
+end
+
+Package.onEditorClose = function(_, editor)
+  manager:release(editor)
+end
+
+Package.onEditorLoad = function(_, editor)
+  manager:cancel(editor)
+end
+
+return Package

--- a/snippets/config.lua
+++ b/snippets/config.lua
@@ -1,0 +1,213 @@
+local IS_WINDOWS = package.config:sub(1,1) == '\\'
+
+local function Color(param)
+  param = (tonumber(param) or 0) % (1+0xFFFFFFFF)
+  local r = param % 256; param = math.floor(param / 256)
+  local b = param % 256; param = math.floor(param / 256)
+  local g = param % 256; param = math.floor(param / 256)
+  return wx.wxColour(r, g, b)
+end
+
+local SnippetConfig = {
+  DEBUG              = true,
+  MARK_SNIPPET       = 4,
+  MARK_SNIPPET_COLOR = Color(IS_WINDOWS and 5085593 or tonumber("0x4D9999")),
+}
+SnippetConfig.__index = SnippetConfig
+
+local function split_scope(str)
+    if not str then
+        return '*', '*'
+    end
+
+    local lang, scope = string.match(str, '^(.-)%.([^%.]*)$')
+    if not lang then
+        return str, '*'
+    end
+
+    if lang == '' then
+        lang = '*'
+    end
+
+    if scope == '' then
+        scope = '*'
+    end
+
+    return lang, scope
+end
+
+local function add_scope(tree, lang, scope)
+    local lang_node = tree[lang] or {}
+    tree[lang] = lang_node
+
+    local scope_node = lang_node[scope] or {}
+    lang_node[scope] = scope_node
+
+    return scope_node
+end
+
+local function find_scope(tree, lang, scope)
+    if not tree then
+        return
+    end
+
+    local node = tree[lang] and (tree[lang][scope] or tree[lang]['*'])
+    if node then
+        return node
+    end
+
+    return tree['*'] and (tree['*'][scope] or tree['*']['*'])
+end
+
+function SnippetConfig.new(class)
+    local self = setmetatable({}, class)
+
+    return self
+end
+
+function SnippetConfig:add_scope(tree, activation_text, snippet)
+    local nested = snippet.nested
+    if nested == nil then
+        nested = self.settings.nested
+    end
+
+    local node = tree[activation_text] or {}
+    tree[activation_text] = node
+
+    --! TODO support multiple scopes
+    local lang, scope = split_scope(snippet.scope)
+    node = add_scope(node, lang, scope)
+
+    node.text   = snippet.text
+    node.nested = nested
+end
+
+function SnippetConfig:add_list(lang, scope, activation_text)
+    local node = add_scope(self._lst, lang, scope, activation_text)
+    local set = node.set or {}
+    node.set = set
+    set[activation_text] = true
+end
+
+function SnippetConfig:build_list()
+    for activation_text, node in pairs(self._tab) do
+        for lang, lang_node in pairs(node) do
+            for scope, scope_node in pairs(lang_node) do
+                self:add_list(lang, scope, activation_text)
+            end
+        end
+    end
+
+    -- scopes `*.<SCOPE>` add to `lang.<SCOPE>` or `lang.*`
+    --   and scopes `*.*` add  to all `lang.`
+    local any_lst = self._lst['*']
+    if any_lst then
+        for lang, lang_node in pairs(self._lst) do
+            if lang ~= '*' then
+                for scope, scope_node in pairs(lang_node) do
+                    for any_scope, any_node in pairs(any_lst) do
+                        if any_scope == scope or scope == '*' then
+                            for activation_text in pairs(any_node.set) do
+                                scope_node.set[activation_text] = true
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    for lang, lang_node in pairs(self._lst) do
+        local any_node = lang_node['*']
+        if any_node then
+            -- scopes `lang.*` add to all `lang.<SCOPE>` nodes
+            for scope, scope_node in pairs(lang_node) do
+                if scope ~= '*' then
+                    for activation_text in pairs(any_node.set) do
+                        scope_node.set[activation_text] = true
+                    end
+                end
+            end
+            -- scopes `lang.*` add to all `*.<SCOPE>` nodes
+            if any_lst and lang ~= '*' then
+                for _, any_lang_node in pairs(any_lst) do
+                    for activation_text in pairs(any_node.set) do
+                        any_lang_node.set[activation_text] = true
+                    end
+                end
+            end
+        end
+    end
+
+    for lang, lang_node in pairs(self._lst) do
+        for scope, scope_node in pairs(lang_node) do
+            local lst = {}
+            for activation_text in pairs(scope_node.set) do
+                table.insert(lst, activation_text)
+            end
+            table.sort(lst)
+            scope_node.set = nil
+            scope_node.lst = lst
+        end
+    end
+
+end
+
+function SnippetConfig:add_snippet(snippet)
+    local activation_type = snippet.activation[1]
+    local activation_text = snippet.activation[2]
+
+    if activation_type == 'tab' then
+        self:add_scope(self._tab, activation_text, snippet)
+    end
+
+    if activation_type == 'key' then
+        self:add_scope(self._key, activation_text, snippet)
+    end
+end
+
+function SnippetConfig:load(config)
+    self._tab = {}
+    self._key = {}
+    self._lst = {}
+
+    self.settings = config.settings or {}
+    if self.settings.nested == nil then
+        self.settings.nested = true
+    end
+    if self.settings.tab_activation == nil then
+        self.settings.tab_activation = true
+    end
+
+    for _, snippet in ipairs(config) do
+        self:add_snippet(snippet)
+    end
+
+    self:build_list()
+
+    return self
+end
+
+function SnippetConfig:get_key(lang, scope, name)
+    return find_scope(self._key[name], lang, scope)
+end
+
+function SnippetConfig:get_tab(lang, scope, name)
+    return find_scope(self._tab[name], lang, scope)
+end
+
+function SnippetConfig:get_key_activators()
+    local keys = {}
+    for key in pairs(self._key) do
+        table.insert(keys, key)
+    end
+    table.sort(keys)
+    return keys
+end
+
+function SnippetConfig:get_list(lang, scope)
+    local list = find_scope(self._lst, lang, scope)
+    return list and list.lst or nil
+end
+
+return SnippetConfig:new()

--- a/snippets/editor.lua
+++ b/snippets/editor.lua
@@ -1,0 +1,275 @@
+---
+-- Some useful functions
+local Editor = {}
+
+local SC_EOL_CRLF = 0
+local SC_EOL_CR   = 1
+local SC_EOL_LF   = 2
+
+local LEXER_NAMES = {}
+for k, v in pairs(wxstc) do
+  if string.find(tostring(k), 'wxSTC_LEX') then
+    local name = string.lower(string.sub(k, 11))
+    LEXER_NAMES[ v ] = name
+  end
+end
+
+-- Get from ru-SciTE. So there no gurantee about correctness for ZBS
+local IS_COMMENT, COMMENTS = {}, {
+  abap       = {1, 2},
+  ada        = {10},
+  asm        = {1, 11},
+  au3        = {1, 2},
+  baan       = {1, 2},
+  bullant    = {1, 2, 3},
+  caml       = {12, 13, 14, 15},
+  cpp        = {1, 2, 3, 15, 17, 18},
+  csound     = {1, 9},
+  css        = {9},
+  d          = {1, 2, 3, 4, 15, 16, 17},
+  escript    = {1, 2, 3},
+  euphoria   = {1, 18},
+  flagship   = {1, 2, 3, 4, 5, 6},
+  forth      = {1, 2, 3},
+  gap        = {9},
+  hypertext  = {9, 20, 29, 42, 43, 44, 57, 58, 59, 72, 82, 92, 107, 124, 125},
+  xml        = {9, 29},
+  inno       = {1, 7},
+  latex      = {4},
+  lua        = {1, 2, 3},
+  script_lua = {4, 5},
+  mmixal     = {1, 17},
+  nsis       = {1, 18},
+  opal       = {1, 2},
+  pascal     = {2, 3, 4},
+  perl       = {2},
+  bash       = {2},
+  pov        = {1, 2},
+  ps         = {1, 2, 3},
+  python     = {1, 12},
+  rebol      = {1, 2},
+  ruby       = {2},
+  scriptol   = {2, 3, 4, 5},
+  smalltalk  = {3},
+  specman    = {2, 3},
+  spice      = {8},
+  sql        = {1, 2, 3, 13, 15, 17, 18},
+  tcl        = {1, 2, 20, 21},
+  verilog    = {1, 2, 3},
+  vhdl       = {1, 2}
+}
+for lang, styles in pairs(COMMENTS) do
+  local set = {}
+  for _, style in ipairs(styles) do
+    set[style] = true
+  end
+  IS_COMMENT[lang] = set
+end
+
+local function IsComment(spec, lang, style)
+  local is_comment = spec and spec.iscomment or IS_COMMENT[lang]
+
+  if is_comment then
+    return is_comment[style]
+  end
+
+  -- For most other lexers comment has style 1
+  -- asn1, ave, blitzbasic, cmake, conf, eiffel, eiffelkw, erlang, euphoria, fortran,
+  -- f77, freebasic, kix, lisp, lout, octave, matlab, metapost, nncrontab, props, batch,
+  -- makefile, diff, purebasic, vb, yaml
+  return style == 1
+end
+
+local function IsString(spec, lang, style)
+  local is_string = spec and spec.isstring
+  return is_string and is_string[style] or false
+end
+
+local function GetStyleName(spec, lang, style)
+  if IsComment(spec, lang, style) then
+    return 'comment'
+  end
+
+  if IsString(spec, lang, style) then
+    return 'string'
+  end
+
+  return 'text'
+end
+
+function Editor.GetLexer(editor)
+  return editor.spec and editor.spec.lexer or editor:GetLexer()
+end
+
+function Editor.GetLanguage(editor)
+  local lexer = Editor.GetLexer(editor)
+  local name = LEXER_NAMES[lexer]
+  if name then return name end
+  if type(lexer) == 'string' then
+    name = string.match(lexer, '^lexlpeg%.(.+)$')
+  end
+  return name or 'UNKNOWN'
+end
+
+function Editor.GetEOL(editor)
+  local eol = "\r\n"
+  if editor.EOLMode == SC_EOL_CR then
+    eol = "\r"
+  elseif editor.EOLMode == SC_EOL_LF then
+    eol = "\n"
+  end
+  return eol
+end
+
+---
+-- Replace all EOL according to editor settings
+function Editor.NormalizeEOL(editor, text)
+  local eol = Editor.GetEOL(editor)
+  text = string.gsub(text, '\r?\n', eol)
+
+  local count, i = -1, -1
+  repeat
+    count = count + 1
+    i = string.find(text, eol, i + 1, true)
+  until i == nil
+
+  return text, count
+end
+
+---
+-- Joins current line with the line below it, eliminating
+-- whitespace.
+-- This is used to remove the empty line containing the end of snippet marker.
+function Editor.JoinLines(editor)
+  -- Move to first non blanck character
+  editor:LineDown() editor:VCHome()
+  if Editor.GetCurrColNumber(editor) == 0 then
+    editor:VCHome()
+  end
+
+  if Editor.GetCurrColNumber(editor) > 0 then
+    editor:HomeExtend()
+    editor:DeleteBack()
+  end
+
+  editor:DeleteBack()
+end
+
+---
+-- When snippets are inserted, match their indentation level
+-- with their surroundings.
+function Editor.AlignIndentation(editor, ref_line, num_lines)
+  if num_lines == 0 then return end
+
+  local base_level  = Editor.GetLineIndentationLevel(editor, ref_line)
+  local indent = editor:GetIndent()
+  for i = 1, num_lines do
+    local line_indent = editor:GetLineIndentation(ref_line + i)
+    editor:SetLineIndentation(ref_line + i, line_indent + base_level * indent)
+  end
+end
+
+function Editor.GetCurrLineNumber(editor)
+  local pos = editor:GetCurrentPos()
+  return editor:LineFromPosition(pos)
+end
+
+function Editor.GetCurrColNumber(editor)
+  local pos = editor:GetCurrentPos()
+  return editor:GetColumn(pos)
+end
+
+function Editor.GetIndentString(editor)
+  if editor:GetUseTabs() then
+    return '\t'
+  end
+
+  local size = editor:GetIndent()
+  if (not size) or (size < 1) then
+    size = 1
+  end
+
+  return string.rep(' ', size)
+end
+
+function Editor.FindText(editor, text, flags, start, finish)
+  editor:SetSearchFlags(flags or 0)
+  editor:SetTargetStart(start or 0)
+  editor:SetTargetEnd(finish or editor:GetLength())
+  local posFind = editor:SearchInTarget(text)
+  if posFind ~= wx.wxNOT_FOUND then
+    start, finish = editor:GetTargetStart(), editor:GetTargetEnd()
+    if start >= 0 and finish >= 0 then
+      return start, finish
+    end
+  end
+  return wx.wxNOT_FOUND, 0
+end
+
+function Editor.ReplaceTextRange(editor, start_pos, end_pos, text)
+  editor:SetSelection(start_pos, end_pos)
+  editor:ReplaceSelection(text)
+end
+
+function Editor.GetSelText(editor)
+  local selection_pos_start, selection_pos_end = editor:GetSelection()
+  local selection_line_start = editor:LineFromPosition(selection_pos_start)
+  local selection_line_end   = editor:LineFromPosition(selection_pos_end)
+
+  local selection = {
+    pos_start    = selection_pos_start,
+    pos_end      = selection_pos_end,
+    first_line   = selection_line_start,
+    last_line    = selection_line_end,
+    is_rectangle = editor:SelectionIsRectangle(),
+    is_multiple  = editor:GetSelections() > 1,
+    text         = ''
+  }
+
+  if selection_pos_start ~= selection_pos_end then
+    if selection.is_rectangle then
+      local EOL = Editor.GetEOL(editor)
+      local selected, not_empty = {}, false
+      for line = selection_line_start, selection_line_end do
+        local selection_line_pos_start = editor:GetLineSelStartPosition(line)
+        local selection_line_pos_end   = editor:GetLineSelEndPosition(line)
+        not_empty = not_empty or selection_line_pos_start ~= selection_line_pos_end
+        append(selected, editor:GetTextRange(selection_line_pos_start, selection_line_pos_end))
+      end
+      selection.text = not_empty and (table.concat(selected, EOL) .. EOL) or ''
+    else
+      selection.text = editor:GetTextRange(selection_pos_start, selection_pos_end)
+    end
+  end
+
+  return selection.text, selection.pos_start, selection.pos_end
+end
+
+function Editor.GetStyleAt(editor, pos)
+  local mask = bit.lshift(1, editor:GetStyleBitsNeeded()) - 1
+  return bit.band(mask, editor:GetStyleAt(pos))
+end
+
+function Editor.GetStyleNameAt(editor, pos)
+  local style = Editor.GetStyleAt(editor, pos)
+  local lang  = Editor.GetLanguage(editor)
+  return GetStyleName(editor.spec, lang, style), lang
+end
+
+function Editor.GetLineIndentationLevel(editor, num_line)
+  if num_line < 0 then num_line = 0 end
+  local count = editor:GetLineCount()
+  if num_line >= count then num_line = count - 1 end
+
+  local line_indent = editor:GetLineIndentation(num_line)
+  local indent = editor:GetIndent()
+  if indent <= 0 then indent = 1 end
+
+  return math.floor(line_indent / indent)
+end
+
+function Editor.HasFocus(editor)
+  return editor == ide:GetEditorWithFocus() and editor
+end
+
+return Editor

--- a/snippets/escape.lua
+++ b/snippets/escape.lua
@@ -1,0 +1,34 @@
+local Escape = {}
+
+local function char_to_byte(char)
+  return string.format('\\%03d', string.byte(char))
+end
+
+local function byte_to_char(value)
+  value = tonumber(value)
+  return '\\'..string.char(value)
+end
+
+---
+-- Replace escaped snippet characters with their octal
+-- equivalents.
+function Escape.encode(text)
+  return string.gsub(text, '\\([$/}`])', char_to_byte)
+end
+
+---
+-- Replace octal snippet characters with their escaped
+-- equivalents.
+function Escape.decode(text)
+  return string.gsub(text, '\\(%d%d%d)', byte_to_char)
+end
+
+---
+-- Remove escaping forward-slashes from escaped snippet
+-- characters.
+-- At this point, they are no longer necessary.
+function Escape.remove(text)
+  return text:gsub('\\([$/}`])', '%1')
+end
+
+return Escape

--- a/snippets/example_config.lua
+++ b/snippets/example_config.lua
@@ -1,0 +1,86 @@
+-- TODO
+-- * shell_executes - currently run only real applications - not shell commands (like `cd` on Windows)
+-- * regex transformatioin - currently uses original implementation based on ruby script. 
+--                           Need to rewrite it using another engine. But need to support features like
+--                           `\u$1` to upper case transformation.
+-- * Improve scope detection
+
+---
+-- Snippet settings
+-- `activation` - { `type`, `activator` }
+--   `type` - can be either `tab` or `key`
+--   `activator` - for `key` type it is shortcut like `Ctrl+B`, for `tab` type it is string without any space chars.
+-- `scope` - <LANG>.<TYPE> 
+--    `LANG` - Language name like it defined for lexer (e.g. `lua`, `perl`). `*` - means any language (default value)
+--    `TYPE` - can be either `text`, `comment` or `string`. `*` - means any type (default value)
+-- `nested` - does it snippet support nested activation
+-- `text` - snippet text.
+--     Macros syntax   - `$(name)` (e.g. `$(SelectedText)`)
+--     Tab stoppers    - `${<NUM>:default}` (note - colon is mandatory)
+--     Shell commands  - ``command`` (e.g. `ls`)
+--     Transformation  - `${<NUM>/pat/rep/flags}` - replace using regex replacement
+--     Mirror `${<NUM>}` - just copy value form tab stopper
+
+snippets = {
+  settings = {
+    nested         = true,
+    tab_activation = true,
+    keys = {
+      ['Alt+J'           ] = 'list',
+      ['Ctrl+J'          ] = 'cancel',
+      ['Ctrl+Shift+J'    ] = 'cancel_all',
+      ['Ctrl+Shift+Alt+J'] = 'show_scope',
+      -- In case of `tab_activation = true`
+      -- ['Ctrl+J'          ] = 'insert', -- `<TAB>`
+      -- ['Ctrl+Shift+J'    ] = 'prev',   -- `Shift+<TAB>`
+    },
+  },
+  { -- shell execute example
+      scope      = '*.*',
+      activation = {'tab', 'ls'},
+      nested     = true,
+      text       = "`ls`",
+  },
+  { -- nested tab stoppers
+      scope      = 'lua',
+      activation = {'tab', 'key'},
+      nested     = true,
+      text       = "['${1:}'] = { ${2:func}${3:, ${4:arg}} }",
+  },
+  { -- mirror
+    scope      = 'lua.text',
+    activation = {'tab', 'tab'},
+    nested     = true,
+    text       = "${3:three} ${1:one} ${2:two} ${3} ${4:four}",
+  },
+  { -- transformation
+      scope      = 'lua',
+      activation = {'tab', 'one'},
+      nested     = true,
+      text       = "${1:two} ${1/two/three/}",
+  },
+  { -- shortcut activator (lang 1)
+      activation = {'key', 'Ctrl+Shift+B'},
+      scope      = 'lua',
+      nested     = true,
+      text       = "<b>$(SelectedText)${0}</b>",
+  },
+  { -- shortcut activator (lang 2)
+      activation = {'key', 'Ctrl+Shift+B'},
+      scope      = 'perl',
+      nested     = true,
+      text       = "document.Write(<b>$(SelectedText)${0}</b>)",
+  },
+  { -- tab activator (lang 1)
+      scope      = 'lua',
+      activation = {'tab', 'f'},
+      nested     = false,
+      text       = "function ${1:name}(${2:})\n$(I)${0}\nend",
+  },
+  { -- tab activator (lang 1)
+        scope      = 'perl',
+        activation = {'tab', 'f'},
+        nested     = false,
+        text       = "sub ${1:name}${2:(${3:arg})}{\n$(I)${0}\n}",
+    },
+}

--- a/snippets/hot_key_toggle.lua
+++ b/snippets/hot_key_toggle.lua
@@ -1,0 +1,32 @@
+local HotKeyToggle = {}
+HotKeyToggle.__index = HotKeyToggle
+
+function HotKeyToggle.new(class, key)
+  local self = setmetatable({}, class)
+
+  self.key = key
+
+  return self
+end
+
+function HotKeyToggle:set(handler)
+  assert(self.id == nil)
+  self.prev = ide:GetHotKey(self.key)
+  self.id = ide:SetHotKey(handler, self.key)
+  return self
+end
+
+function HotKeyToggle:unset()
+  assert(self.id ~= nil)
+  if self.id == ide:GetHotKey(self.key) then
+    if self.prev then
+      ide:SetHotKey(self.prev, self.key)
+    else
+      --! @todo properly remove handler
+      ide:SetHotKey(function()end, self.key)
+    end
+  end
+  self.prev, self.id = nil
+end
+
+return HotKeyToggle

--- a/snippets/log.lua
+++ b/snippets/log.lua
@@ -1,0 +1,61 @@
+local config = package_require 'snippets.config'
+
+local function print(...)
+  ide:Print(...)
+end
+
+local Log = {} do
+  Log.__index = Log
+
+  Log.ERROR   = 0
+  Log.WARNING = 1
+  Log.DEBUG   = 2
+
+  function Log.new(class, prefix, lvl)
+    local self = setmetatable({}, class)
+    self.prefix = prefix
+    self.level = lvl or Log.WARNING
+    self.loggers = {}
+    return self
+  end
+
+  function Log:get(prefix, lvl)
+    local log = self.loggers[prefix]
+    if not log then
+      local class = getmetatable(self)
+      log = Log.new(class, self.prefix .. ':' .. prefix, lvl or self.level)
+      self.loggers[prefix] = log
+    end
+    return log
+  end
+
+  function Log:format(lvl, ...)
+    local msg = string.format(...)
+    return string.format('%s [%s][%s] %s',  os.date('%H:%M:%S'), lvl, self.prefix, msg)
+  end
+
+  function Log:write(...)
+    local msg = self:format(...)
+    print(msg)
+  end
+
+  function Log:debug(...)
+    if self.level >= Log.DEBUG then
+      self:write('DEBUG', ...)
+    end
+  end
+
+  function Log:warning(...)
+    if self.level >= Log.WARNING then
+      self:write('WARNING', ...)
+    end
+  end
+
+  function Log:error(...)
+    if self.level >= Log.ERROR then
+      self:write('ERROR', ...)
+    end
+  end
+end
+
+return Log:new('snippets', config.DEBUG and Log.DEBUG or Log.WARNING)

--- a/snippets/manager.lua
+++ b/snippets/manager.lua
@@ -1,0 +1,248 @@
+local config        = package_require 'snippets.config'
+local log           = package_require 'snippets.log'
+local Editor        = package_require 'snippets.editor'
+local SnippetStack  = package_require 'snippets.stack'
+
+local function pget(t, ...)
+  for i = 1, select('#', ...) do
+    local idx = select(i, ...)
+    if type(t) ~= 'table' then
+      return nil
+    end
+    t = t[idx]
+  end
+  return t
+end
+
+local function pget_string(...)
+  local value = pget(...)
+  return type(value) == 'string' and value or nil
+end
+
+local function re_match(re, str)
+  if not re:Matches(str) then
+    return nil
+  end
+  return re:GetMatch(str, 1)
+end
+
+local re = wx.wxRegEx('([^ ]+)$')
+local function get_last_word(str)
+  if str == '' then
+    return nil
+  end
+
+  local s = re_match(re, str)
+  if s == '' then
+    s = nil
+  end
+
+  return s
+end
+
+local function get_line_start(editor)
+  local current_pos    = editor:GetCurrentPos()
+  local line_start_pos = editor:PositionFromLine(editor:LineFromPosition(current_pos))
+  if line_start_pos == current_pos then
+    return ''
+  end
+  return editor:GetTextRange(line_start_pos, current_pos)
+end
+
+local SnippetManager = {} do
+  SnippetManager.__index = SnippetManager
+
+  function SnippetManager.new(class)
+    local self = setmetatable({}, class)
+
+    self._stack = {} or setmetatable({}, {__mode = 'v'})
+
+    return self
+  end
+
+  function SnippetManager:create_stack(editor)
+    local stack = self._stack[tostring(editor)]
+    if not stack then
+      stack = SnippetStack:new(editor)
+      self._stack[tostring(editor)] = stack
+      editor:MarkerSetBackground(config.MARK_SNIPPET, config.MARK_SNIPPET_COLOR)
+    end
+    return stack
+  end
+
+  function SnippetManager:get_stack(editor)
+    return self._stack[tostring(editor)]
+  end
+
+  function SnippetManager:has_active_snippet(editor)
+    local stack = self:get_stack(editor)
+    if not stack then
+      return false
+    end
+    return stack:active()
+  end
+
+  function SnippetManager:allow_new_snippet(editor)
+    local stack = self:get_stack(editor)
+    if not stack then
+      return true
+    end
+    return stack:allow_new_snippet()
+  end
+
+  function SnippetManager:release(editor)
+    local log = log:get('SnippetManager:release')
+    if self._stack[tostring(editor)] then
+      log:debug('editor %s', tostring(editor))
+      self._stack[tostring(editor)] = nil
+    end
+  end
+
+  function SnippetManager:get_last_word(editor)
+    local str = get_line_start(editor)
+    return get_last_word(str)
+  end
+
+  function SnippetManager:find_snippet_text(editor, snippet_arg)
+    local log = log:get('SnippetManager:find_snippet_text')
+
+    if snippet_arg then
+      local cursor_pos  = editor:GetCurrentPos()
+      local scope, lang = Editor.GetStyleNameAt(editor, cursor_pos)
+      log:debug('Cursor: %d; Lexer: %s; Scope: %s; Key: %s', cursor_pos, lang, scope, snippet_arg)
+
+      local snippet_text = config:get_key(lang, scope, snippet_arg)
+      if not (snippet_text and snippet_text.text) then
+        log:debug('Snippet not found')
+        return
+      end
+
+      -- Move Cursor to the beginning of selection
+      local anchor = editor:GetAnchor()
+      if cursor_pos > anchor then
+        editor:SetCurrentPos(anchor)
+        editor:SetAnchor(cursor_pos)
+        cursor_pos = editor:GetCurrentPos()
+      end
+
+      return cursor_pos, cursor_pos, snippet_text
+    end
+
+    local snippet_name = self:get_last_word(editor)
+    if not snippet_name then
+      log:debug('Snippet name not found')
+      return
+    end
+
+    local cursor_pos   = editor:GetCurrentPos()
+    local scope, lang = Editor.GetStyleNameAt(editor, cursor_pos)
+    log:debug('Cursor: %d; Lexer: %s; Scope: %s, Name: %s', cursor_pos, lang, scope, snippet_name)
+
+    local snippet_text = config:get_tab(lang, scope, snippet_name)
+
+    if not snippet_text then
+      log:debug('Snippet not found')
+      return
+    end
+
+    local start_pos  = cursor_pos - #snippet_name
+
+    log:debug('Origin cursor pos: %d (at line %d) Start pos: %d (at line %d)',
+      cursor_pos, editor:LineFromPosition(cursor_pos),
+      start_pos,  editor:LineFromPosition(start_pos)
+    )
+
+    return cursor_pos, start_pos, snippet_text, snippet_name
+  end
+
+  function SnippetManager:cancel_current(editor)
+    local stack = self:get_stack(editor)
+    if not stack then
+      return
+    end
+    stack:cancel_current()
+  end
+
+  function SnippetManager:cancel(editor)
+    local log = log:get('SnippetManager:cancel')
+    local stack = self:get_stack(editor)
+    if stack then
+      log:debug('editor %s', tostring(editor))
+      stack:cancel_all()
+    end
+  end
+
+  function SnippetManager:prev(editor)
+    local stack = self:get_stack(editor)
+    if not stack then
+      return
+    end
+    stack:prev()
+  end
+
+  function SnippetManager:next(editor)
+    local stack = self:get_stack(editor)
+    if not stack then
+      log:get('SnippetManager:next'):debug('Stack not found')
+      return
+    end
+    stack:next()
+  end
+
+  function SnippetManager:start_snippet(editor, snippet_arg)
+    local cursor_pos, start_pos, snippet_text, snippet_name = self:find_snippet_text(editor, snippet_arg)
+
+    if cursor_pos then
+      local stack = self:create_stack(editor)
+      stack:push(cursor_pos, start_pos, snippet_name, snippet_text)
+    end
+  end
+
+  function SnippetManager:insert(editor, snippet_arg)
+    if self:allow_new_snippet(editor) then
+      self:start_snippet(editor, snippet_arg)
+    end
+
+    local is_active = self:has_active_snippet(editor)
+    self:next(editor)
+    return is_active
+  end
+
+  ---
+  -- Show the scope/style at the current caret position as a calltip.
+  function SnippetManager:show_scope(editor)
+    local pos          = editor:GetCurrentPos()
+    local scope, lexer = Editor.GetStyleNameAt(editor, pos)
+
+    local text = 'Lexer: ' .. lexer .. '\nScope: ' .. scope
+    editor:CallTipShow(pos, text)
+  end
+
+  ---
+  -- List available snippet triggers as an autocompletion list.
+  -- Global snippets and snippets in the current lexer and scope are used.
+  function SnippetManager:snippet_list(editor)
+    if not Editor.HasFocus(editor) then
+      return
+    end
+
+    local pos   = editor:GetCurrentPos()
+    local lexer, scope = Editor.GetStyleNameAt(editor, pos)
+    local list = config:get_list(lexer, scope)
+    if not (list and list[1]) then
+        return
+    end
+
+    local sep = string.char(editor:AutoCompGetSeparator())
+    list = table.concat(list, sep)
+    editor:AutoCompShow(0, list)
+  end
+
+  function SnippetManager:load_config(cfg)
+    config:load(cfg)
+    return config
+  end
+
+end
+
+return SnippetManager

--- a/snippets/snippet.lua
+++ b/snippets/snippet.lua
@@ -1,0 +1,385 @@
+local config        = package_require 'snippets.config'
+local log           = package_require 'snippets.log'
+local Editor        = package_require 'snippets.editor'
+local shell_execute = package_require 'snippets.utils.shell_execute'
+local ruby_regexp   = package_require 'snippets.utils.ruby_regexp'
+local escape_encode = package_require 'snippets.escape'.encode
+local escape_decode = package_require 'snippets.escape'.decode
+local escape_remove = package_require 'snippets.escape'.remove
+
+local function get_macros(editor, selected_text)
+  -- TODO support more macros
+  local macros = {
+    SelectedText = selected_text or '',
+    I            = Editor.GetIndentString(editor),
+  }
+  return macros
+end
+
+local Snippet = {}
+Snippet.__index = Snippet
+
+function Snippet.new(class, editor, cursor_pos, start_pos, snippet_name, snippet)
+  local self = setmetatable({}, class)
+
+  local selected_text, selection_pos_start, selection_pos_end = Editor.GetSelText(editor)
+  local selected_len = math.abs(selection_pos_end - selection_pos_start)
+
+  local macros = get_macros(editor, selected_text)
+
+  local snippet_text = snippet.text
+
+  local count
+  snippet_text = escape_encode(snippet_text)
+  snippet_text = self:expand_macros(snippet_text, macros)
+  snippet_text = self:expand_shell(snippet_text)
+  snippet_text, count = Editor.NormalizeEOL(editor, snippet_text)
+
+  if selected_text == '' then
+    selected_text = nil
+  end
+
+  if selected_text then
+    selected_len = selected_len or #selected_text
+  else
+    selected_len = nil
+  end
+
+  self.index        = 0
+  self.nested       = snippet.nested
+  self.editor       = editor
+  self.name         = snippet_name
+  self.cursor_pos   = cursor_pos
+  self.start_pos    = start_pos
+  self.sel_text     = selected_text
+  self.sel_len      = selected_len
+  self.text         = escape_decode(snippet_text)
+  self.line_count   = count
+  self.placeholders = self:collect_placeholders(snippet_text)
+  self.snapshots    = {}
+  self.cursor       = nil
+  self.end_marker   = nil
+
+  return self
+end
+
+---
+-- Replace selected text in editor to a snippet value
+function Snippet:start()
+  self.editor:BeginUndoAction()
+  self:insert_text()
+  self.editor:EndUndoAction()
+end
+
+---
+-- Insert the snippet and set a mark defining the end of it.
+function Snippet:insert_text()
+  if self.name then -- use tab activator
+    -- this call uses to close autocomplite list
+    self.editor:WordLeftExtend()
+    -- select snippet name
+    self.editor:SetSelection(self.start_pos, self.cursor_pos)
+  end
+  self.editor:ReplaceSelection(self.text)
+  self:set_end_marker()
+  self:indent()
+end
+
+---
+-- Insert end of snippet marker to editor
+function Snippet:set_end_marker()
+  self.editor:NewLine()
+  local line = Editor.GetCurrLineNumber(self.editor)
+  self.end_marker = self.editor:MarkerAdd(line, config.MARK_SNIPPET)
+end
+
+---
+-- Indent all lines inserted.
+function Snippet:indent()
+  self.editor:SetCurrentPos(self.start_pos)
+  local line = Editor.GetCurrLineNumber(self.editor)
+  Editor.AlignIndentation(self.editor, line, self.line_count)
+end
+
+---
+-- Cancels active snippet, reverting to the state before the snippet was
+-- activated.
+function Snippet:cancel()
+  local s_start, s_end = self:get_pos()
+  if s_start and s_end then
+    Editor.ReplaceTextRange(self.editor, s_start, s_end, '')
+    Editor.JoinLines(self.editor)
+  end
+
+  if self.sel_text then
+    self.editor:AddText(self.sel_text)
+    local anchor = self.editor:GetAnchor() - self.sel_len
+    self.editor:SetAnchor(anchor)
+  elseif self.name then
+    self.editor:AddText(self.name)
+  end
+
+  self.editor:MarkerDeleteHandle(self.end_marker)
+end
+
+---
+-- Moves to the next placeholder. Finish snippiet if there no one
+function Snippet:next_placeholder(s_start, s_end, s_text)
+  local log = log:get('Snippet:next_placeholder')
+
+  self.index = self.index + 1
+
+  if not self.placeholders[self.index] then
+    self:finish(s_text)
+    return true
+  end
+
+  log:debug('next index: %d', self.index)
+
+  self.editor:BeginUndoAction()
+  local pass = self:replace_placeholder(s_start, s_end, s_text)
+  self.editor:EndUndoAction()
+
+  if not pass then
+    return false
+  end
+
+  return true
+end
+
+---
+-- Replace text with the default value for a current placeholder
+function Snippet:replace_placeholder(s_start, s_end, s_text)
+  local log = log:get('Snippet:replace_placeholder')
+
+  local next_item = self:next_item(s_text)
+  if not next_item then
+    log:error('no item for placeholder %d', self.index)
+    return false
+  end
+  log:debug('next item:\n%s\n============', next_item)
+
+  s_text = escape_decode(s_text)
+  log:debug('unescaped:\n%s\n============', s_text)
+
+  Editor.ReplaceTextRange(self.editor, s_start, s_end, s_text)
+  s_start, s_end = self:get_pos()
+
+  local placeholder_start, placeholder_end
+  if s_start then
+    placeholder_start, placeholder_end = Editor.FindText(self.editor, next_item, 0, s_start, s_end)
+  end
+
+  if placeholder_start and placeholder_end and placeholder_start >= 0 then
+    self.cursor = placeholder_start
+    local default = string.match(next_item, '^%${' .. self.index .. ':(.*)}$')
+    Editor.ReplaceTextRange(self.editor, placeholder_start, placeholder_end, default)
+    self.editor:SetSelection(placeholder_start, self.editor:GetCurrentPos())
+    return true
+  end
+
+  log:error('can not find next_item in the editor:\n%s\n============', next_item)
+  return false
+end
+
+---
+-- Revers the state before last placeholder was activated.
+-- Returns true in case of success
+function Snippet:prev_placeholder()
+  local log = log:get('Snippet:prev_placeholder')
+  local index = self.index - 2
+  if index >= 0 then
+    self.index = index
+    log:debug('next index: %d', index)
+
+    local s_text = self.snapshots[index]
+    log:debug('snapshot[%d]:\n%s\n============', index, s_text)
+
+    local s_start, s_end = self:get_pos()
+    if s_start then
+      Editor.ReplaceTextRange(self.editor, s_start, s_end, s_text)
+    end
+
+    return true
+  end
+end
+
+---
+-- Saves snapshot for current placeholder
+function Snippet:push_snapshot(s_text)
+  self.snapshots[self.index] = s_text
+end
+
+function Snippet:finish_reset_text(s_text)
+  local log = log:get('Snippet:finish')
+  local s_start, s_end = self:get_pos()
+  if not s_start then
+    log:debug('snippet not found')
+    return
+  end
+
+  s_text = s_text:gsub('${0}', '$CURSOR', 1)
+  s_text = escape_decode(s_text)
+  log:debug('unescaped:\n%s\n============', s_text)
+
+  s_text = escape_remove(s_text)
+  log:debug('escapes removed:\n%s\n============', s_text)
+  Editor.ReplaceTextRange(self.editor, s_start, s_end, s_text)
+
+  s_start, s_end = self:get_pos()
+  if not s_start then
+    log:error('Can not find snippet after cursor replacement')
+    return
+  end
+
+  log:debug('Move cursor to pos: %d (at line %d)',
+    s_end, self.editor:LineFromPosition(s_end)
+  )
+  self.editor:SetSelection(s_end, s_end)
+  Editor.JoinLines(self.editor)
+
+  local s, e = Editor.FindText(self.editor, '$CURSOR', wxstc.wxSTC_FIND_MATCHCASE, s_start, s_end)
+  log:debug('search cursor: search range [%s, %s]; result [%s, %s]', tostring(s_start), tostring(s_end), tostring(s), tostring(e))
+  if s and e and s >= 0 then
+    Editor.ReplaceTextRange(self.editor, s, e, '')
+  else
+    self.editor:SetSelection(s_end, s_end) -- at snippet end marker
+  end
+end
+
+function Snippet:finish(s_text)
+  local log = log:get('Snippet:finish')
+  log:debug('Starting...')
+  self.editor:BeginUndoAction()
+  self:finish_reset_text(s_text)
+  self.editor:MarkerDeleteHandle(self.end_marker)
+  self.editor:EndUndoAction()
+  self.index = nil
+  log:debug('Done')
+end
+
+function Snippet:next_item(s_text)
+  local start = string.find(s_text, '${' .. self.index .. ':', nil, true)
+  if not start then
+    return nil
+  end
+
+  local next_item = string.match(s_text, '($%b{})', start)
+  if not next_item then
+    return nil
+  end
+
+  return escape_decode(next_item)
+end
+
+-- Mirror and transform.
+function Snippet:mirror(s_text)
+  s_text = escape_encode(s_text)
+
+  if self.index > 0 then
+    if self.cursor then
+      self.editor:SetSelection(self.cursor, self.editor:GetCurrentPos())
+    else
+      self.editor:WordLeftExtend()
+    end
+
+    local last_item = Editor.GetSelText(self.editor)
+
+    -- Regex mirror.
+    s_text = self:expand_pattern(s_text, last_item)
+
+    -- Plain text mirror.
+    s_text = self:expand_plain(s_text, last_item)
+  end
+
+  return s_text
+end
+
+local function _expand_shell(code)
+    local log = log:get('Snippet:expand_shell')
+    log:debug('execute: %s', code)
+    local ret, stdout, stderr = shell_execute(code)
+    if ret ~= 0 then
+      log:error('code: %d\n%s\n============', ret, stderr)
+      return ''
+    end
+    return stdout
+end
+
+function Snippet:expand_shell(text)
+  return text:gsub('`(.-)`', _expand_shell)
+end
+
+function Snippet:expand_macros(text, macros)
+  return (string.gsub(text, '%$%((.-)%)', macros))
+end
+
+function Snippet:expand_pattern(text, last_item)
+  local patt = '%${' .. self.index .. '/(.-)/(.-)/([iomxneus]*)}'
+  text = string.gsub(text, patt, function(pattern, replacement, options)
+    return ruby_regexp(last_item, pattern, replacement, options)
+  end)
+  return text
+end
+
+function Snippet:expand_plain(text, last_item)
+  local mirror = '%${' .. self.index .. '}'
+  text = string.gsub(text, mirror, last_item)
+  return text
+end
+
+function Snippet:collect_placeholders(text)
+  local placeholders = {}
+
+  local item_patt, index_patt = '()($%b{})', '^%${(%d+):.*}$'
+
+  local pos, item = string.match(text, item_patt)
+  while item do
+    local index = string.match(item, index_patt)
+    if index then
+      placeholders[ tonumber(index) ] = true
+    end
+    pos, item = string.match(text, item_patt, pos + 1)
+  end
+
+  return placeholders
+end
+
+---
+-- [Local function] Gets the text of the snippet.
+-- This is the text bounded by the start of the trigger word to the end snippet
+-- marker on the line after the snippet's end.
+function Snippet:get_text()
+  local snippet_start, snippet_end = self:get_pos()
+  if not snippet_start then
+    return
+  end
+
+  local text = self.editor:GetTextRange(snippet_start, snippet_end)
+  return snippet_start, snippet_end, text
+end
+
+---
+-- [Local function] Gets the snippet start and end position
+function Snippet:get_pos()
+  local snippet_start = self.start_pos
+  local snippet_end   = self:get_end_pos()
+
+  if snippet_start > snippet_end then
+    return
+  end
+
+  return snippet_start, snippet_end
+end
+
+function Snippet:get_end_pos()
+  local eol = Editor.GetEOL(self.editor)
+  local line = self.editor:MarkerLineFromHandle(self.end_marker)
+  return self.editor:PositionFromLine(line) - #eol
+end
+
+function Snippet:support_nested()
+  return self.nested
+end
+
+return Snippet

--- a/snippets/stack.lua
+++ b/snippets/stack.lua
@@ -1,0 +1,117 @@
+local log           = package_require 'snippets.log'
+local Snippet       = package_require 'snippets.snippet'
+local escape_decode = package_require 'snippets.escape'.decode
+
+local Stack = {} do
+  Stack.__index = Stack
+
+  function Stack.new(class, editor)
+    local self = setmetatable({}, class)
+
+    self._stack  = {}
+
+    return self
+  end
+
+  function Stack:top()
+    local snippet = self._stack[#self._stack]
+    return snippet
+  end
+
+  function Stack:push(snippet)
+    table.insert(self._stack, snippet)
+  end
+
+  function Stack:pop()
+    return table.remove(self._stack)
+  end
+end
+
+local SnippetStack = {} do
+  SnippetStack.__index = SnippetStack
+
+  function SnippetStack.new(class, editor)
+    local self = setmetatable({}, class)
+
+    self._stack = Stack:new()
+    self.editor = editor
+
+    return self
+  end
+
+  function SnippetStack:push(...)
+    local snippet = Snippet:new(self.editor, ...)
+    self._stack:push(snippet)
+    snippet:start()
+  end
+
+  function SnippetStack:next()
+    local snippet = self._stack:top()
+    if not snippet then return end
+
+    local log = log:get('SnippetStack:next')
+
+    local s_start, s_end, s_text = snippet:get_text()
+
+    -- If something went wrong and the snippet has been 'messed' up
+    -- (e.g. by undo/redo commands).
+    if not s_text then
+      log:debug('Cancel snippet')
+      return self:cancel_current()
+    end
+
+    snippet:push_snapshot(s_text)
+    log:debug('snapshot[%d]:\n%s\n============', snippet.index, s_text)
+
+    s_text = snippet:mirror(s_text)
+    log:debug('mirrored:\n%s\n============', s_text)
+
+    if not snippet:next_placeholder(s_start, s_end, s_text) then
+      return self:next()
+    end
+
+    if not snippet.index then
+        assert(snippet == self._stack:pop())
+    end
+  end
+
+  function SnippetStack:prev()
+    local snippet = self._stack:top()
+    if not snippet then return end
+
+    if snippet:prev_placeholder() then
+      self:next()
+    end
+  end
+
+  function SnippetStack:cancel_current()
+    local snippet = self._stack:pop()
+    if not snippet then return end
+
+    snippet:cancel()
+  end
+
+  function SnippetStack:cancel_all()
+    while true do
+      local snippet = self._stack:pop()
+      if not snippet then return end
+      snippet:cancel()
+    end
+  end
+
+  function SnippetStack:active()
+    local snippet = self._stack:top()
+    return snippet and true or false
+  end
+
+  function SnippetStack:allow_new_snippet(editor)
+    local snippet = self._stack:top()
+    if not snippet then
+      return true
+    end
+    return snippet:support_nested()
+  end
+
+end
+
+return SnippetStack

--- a/snippets/utils/remove_file.lua
+++ b/snippets/utils/remove_file.lua
@@ -1,0 +1,1 @@
+return os.remove

--- a/snippets/utils/ruby_regexp.lua
+++ b/snippets/utils/ruby_regexp.lua
@@ -1,0 +1,54 @@
+local shell_execute = package_require 'snippets.utils.shell_execute'
+local write_file    = package_require 'snippets.utils.write_file'
+local remove_file   = package_require 'snippets.utils.remove_file'
+local tmpname       = package_require 'snippets.utils.tmpname'
+local escape_decode = package_require 'snippets.escape'.decode
+
+local RUBY_CMD = 'ruby'
+
+---
+-- Replace regexp using ruby interpreter
+local function ruby_regexp(last_item, pattern, replacement, options)
+  local script = [[
+    li  = %q(last_item)
+    rep = %q(replacement)
+    li  =~ /pattern/options
+    if data = $~
+      rep.gsub!(/\#\{(.+?)\}/) do
+        expr = $1.gsub(/\$(\d\d?)/, 'data[\1]')
+        eval expr
+      end
+      puts rep.gsub(/\$(\d\d?)/) { data[$1.to_i] }
+    end
+  ]]
+  pattern     = escape_decode(pattern)
+  replacement = escape_decode(replacement)
+  script = script:gsub('last_item', last_item)
+  script = script:gsub('pattern', pattern)
+  script = script:gsub('options', options)
+  script = script:gsub('replacement', replacement)
+
+  local file = tmpname()
+  write_file(file, script)
+
+  local ret, response, stderr = shell_execute(RUBY_CMD .. ' -cw ' .. file)
+  if (ret ~= 0) or not (response and response:sub(1, 9) == 'Syntax OK') then
+    remove_file(file)
+    local log = log:get('ruby_regexp')
+    log:error('%s\n============', stderr)
+    return ''
+  end
+
+  ret, response, stderr = shell_execute(RUBY_CMD .. ' ' .. file)
+  remove_file(file)
+
+  if ret ~= 0 then
+    local log = log:get('ruby_regexp')
+    log:error('%s\n============', stderr)
+    return ''
+  end
+
+  return response
+end
+
+return ruby_regexp

--- a/snippets/utils/shell_execute.lua
+++ b/snippets/utils/shell_execute.lua
@@ -1,0 +1,21 @@
+local wx = wx
+
+---
+-- execute shell command and stdout return
+local shell_execute_flags = wx.wxEXEC_SYNC + (wx.wxEXEC_NOEVENTS or 0) + (wx.wxEXEC_HIDE_CONSOLE or 0)
+
+local function shell_execute(code)
+  local ret, stdout, stderr = wx.wxExecuteStdoutStderr(code, shell_execute_flags)
+
+  if stdout then
+    stdout = table.concat(stdout, '\n')
+  end
+
+  if stderr then
+    stderr = table.concat(stderr, '\n')
+  end
+
+  return ret, stdout, stderr
+end
+
+return shell_execute

--- a/snippets/utils/tmpname.lua
+++ b/snippets/utils/tmpname.lua
@@ -1,0 +1,27 @@
+local DIR_SEP    = package.config:sub(1,1)
+local IS_WINDOWS = DIR_SEP == '\\'
+
+local function splitpath(P)
+  return string.match(P,"^(.-)[\\/]?([^\\/]*)$")
+end
+
+local function tmpdir()
+  if IS_WINDOWS then
+    for _, p in ipairs{'TEMP', 'TMP'} do
+      local dir = os.getenv(p)
+      if dir and dir ~= '' then
+        return dir
+      end
+    end
+  end
+  return (splitpath(os.tmpname()))
+end
+
+local TMP_DIR = tmpdir()
+
+local function tmpname()
+  local dir, file = splitpath(os.tmpname())
+  return TMP_DIR .. DIR_SEP .. file
+end
+
+return tmpname

--- a/snippets/utils/write_file.lua
+++ b/snippets/utils/write_file.lua
@@ -1,0 +1,7 @@
+local function write_file(name, data)
+  local f = assert(io.open(name, 'w'))
+  f:write(data)
+  f:close()
+end
+
+return write_file


### PR DESCRIPTION
This plagin based on [scite-tools/snippets](https://github.com/btakita/scite-tools/blob/master/scripts/scite/snippets.lua) plugin.
I did not use code snippets yet so I have no expirience with it and may be some thing need change. So I really hope to any feedback. I tested this code only under Windows. I have plan to do this on Ubuntu as whell, but may be only on a next week.

My TODO list
 * regex transformatioin - currently uses original implementation based on ruby script. It is slow and does not suppert features like upper case. But I did not find better way. (Perl can do this but I prefer to use some Lua library)
 * shell_executes - currently run only real applications - not shell commands (like `cd` on Windows). I am not sure I need it so for now I have plan to leave it as is.
* Improve scope detection - Persenally I use only few lexers (mostly Lua and Perl) and there all seems work as expected.
* Support loading snippets from file. I have no huge snippets (yet?), so do not neet it righ now.

Also, I think about add `package_require` function to ZBS source code. Its really ugly right now, but I really do not put all code in the one file.