### PR TITLE
Add Fennel plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ this means that it requires a development version currently being worked on (whi
 * [eris.lua](eris.lua): Implements integration with the Lua + Eris interpreter (5.3).
 * [escapetoquit.lua](escapetoquit.lua): Exits application on Escape.
 * [extregister.lua](extregister.lua): Registers known extensions to launch the IDE on Windows.
+* [fennel.lua](fennel.lua): Runs Fennel programs.
 * [filetreeoneclick.lua](filetreeoneclick.lua): Changes filetree to activate items on one-click (as in Sublime Text).
 * [hidemenu.lua](hidemenu.lua): Hides and shows the menu bar when pressing alt.
 * [hidemousewhentyping.lua](hidemousewhentyping.lua): Hides mouse cursor when typing.

--- a/fennel.lua
+++ b/fennel.lua
@@ -1,0 +1,83 @@
+-- Copyright 2014 Paul Kulchenko, ZeroBrane LLC; All rights reserved
+
+-- based on the moonscript plugin
+
+-- TODO: only activate when in a .fnl file?
+-- TODO: how to run a repl vs running the file?
+
+local exe
+local win = ide.osname == "Windows"
+
+local fennel = {
+  name = "Fennel",
+  description = "Fennel runner",
+  api = {"baselib"},
+  frun = function(self,wfilename)
+    exe = exe or ide.config.path.fennel -- check if the path is configured
+    if not exe then
+      local sep = win and ';' or ':'
+      local default = win and GenerateProgramFilesPath('fennel', sep)..sep or ''
+      local path = default
+        ..(os.getenv('PATH') or '')..sep
+        ..(GetPathWithSep(self:fworkdir(wfilename)))..sep
+        ..(os.getenv('HOME') and GetPathWithSep(os.getenv('HOME'))..'bin' or '')
+      local paths = {}
+      for p in path:gmatch("[^"..sep.."]+") do
+        exe = exe or GetFullPathIfExists(p, win and 'fennel.exe' or 'fennel')
+        table.insert(paths, p)
+      end
+      if not exe then
+        ide:Print("Can't find fennel executable in any of the following folders: "
+                    ..table.concat(paths, ", "))
+        return
+      end
+    end
+
+    local filepath = wfilename:GetFullPath()
+    -- if running on Windows and can't open the file, this may mean that
+    -- the file path includes unicode characters that need special handling
+    local fh = io.open(filepath, "r")
+    if fh then fh:close() end
+    if ide.osname == 'Windows' and pcall(require, "winapi")
+    and wfilename:FileExists() and not fh then
+      winapi.set_encoding(winapi.CP_UTF8)
+      filepath = winapi.short_path(filepath)
+    end
+
+    local params = ide.config.arg.any or ide.config.arg.fennel
+    local code = ([["%s"]]):format(filepath)
+    local cmd = '"'..exe..'" '..code..(params and " "..params or "")
+
+    return CommandLineRun(cmd,self:fworkdir(wfilename),true)
+  end,
+  fprojdir = function(self,wfilename)
+    return wfilename:GetPath(wx.wxPATH_GET_VOLUME)
+  end,
+  fworkdir = function(self,wfilename)
+    return ide.config.path.projectdir or wfilename:GetPath(wx.wxPATH_GET_VOLUME)
+  end,
+  hasdebugger = false,
+  skipcompile = true,
+  unhideanywindow = true,
+  takeparameters = true,
+}
+
+return {
+  name = "Fennel",
+  description = "Implements integration with Fennel language.",
+  author = "Phil Hagelberg",
+  version = 0.1,
+  dependencies = "1.60",
+
+  onRegister = function(self)
+    ide:AddInterpreter("fennel", fennel)
+  end,
+  onUnRegister = function(self)
+    ide:RemoveInterpreter("fennel")
+  end,
+}
+
+--[[ configuration example:
+-- if `fennel` executable is not in PATH, set the path to it manually
+path.fennel = "/full/path/to/fennel"
+--]]


### PR DESCRIPTION
I have it working such that it can run the current file in a subprocess; this is basically cribbed from the `moonscript.lua` plugin and simplified since we don't have mobdebug support (yet).

However, it's missing the ability to start an interactive REPL (aka "console") session where you can send it code one expression at a time. I couldn't find anything in the docs about how to do this from a plugin, but this is a key feature for developing Fennel programs.

Also I was wondering if there was a way to make it so this doesn't show up in the "interpreters" menu unless you're currently editing a `*.fnl` file; I couldn't see anything about that in the documentation.

thanks!